### PR TITLE
Make IPool mint/burn functions more abstract

### DIFF
--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -3,7 +3,7 @@
 pragma solidity >=0.5.0;
 pragma experimental ABIEncoderV2;
 
-/// @notice Interface for Trident exchange pool interactions.
+/// @notice Trident exchange pool interface.
 interface IPool {
     event Swap(
         address indexed recipient,


### PR DESCRIPTION
for better composability between different pool types, abstract `mint` and ` burn` functions to take data param.