### PR TITLE
fix getNamedSigner is not function issue #146

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -15,6 +15,8 @@ import "@typechain/hardhat";
 import "hardhat-tracer";
 import "./cli";
 
+import "hardhat-deploy-ethers";
+
 import { HardhatUserConfig } from "hardhat/config";
 import { removeConsoleLog } from "hardhat-preprocessor";
 


### PR DESCRIPTION
missing
`import "hardhat-deploy-ethers";`
in hardhat.config.ts

so `getNamedSigner` cannot work