### PR TITLE
Update variable naming - secondsPerLiquidity  to secondsGrowthGlobal

### DIFF
--- a/contracts/interfaces/IConcentratedLiquidityPool.sol
+++ b/contracts/interfaces/IConcentratedLiquidityPool.sol
@@ -48,5 +48,5 @@ interface IConcentratedLiquidityPool is IPool {
 
     function getReserves() external view returns (uint128 _reserve0, uint128 _reserve1);
 
-    function getSecondsPerLiquidityAndLastObservation() external view returns (uint160 _secondsPerLiquidity, uint32 _lastObservation);
+    function getSecondsGrowthAndLastObservation() external view returns (uint160 _secondGrowthGlobal, uint32 _lastObservation);
 }

--- a/contracts/libraries/concentratedPool/Ticks.sol
+++ b/contracts/libraries/concentratedPool/Ticks.sol
@@ -13,7 +13,7 @@ library Ticks {
         uint128 liquidity;
         uint256 feeGrowthOutside0; // Per unit of liquidity.
         uint256 feeGrowthOutside1;
-        uint160 secondsPerLiquidityOutside;
+        uint160 secondsGrowthOutside;
     }
 
     function getMaxLiquidity(uint24 _tickSpacing) internal pure returns (uint128) {
@@ -23,12 +23,12 @@ library Ticks {
     function cross(
         mapping(int24 => Tick) storage ticks,
         int24 nextTickToCross,
-        uint160 secondsPerLiquidity,
+        uint160 secondsGrotwhGlobal,
         uint256 currentLiquidity,
         uint256 feeGrowthGlobal,
         bool zeroForOne
     ) internal returns (uint256, int24) {
-        ticks[nextTickToCross].secondsPerLiquidityOutside = secondsPerLiquidity - ticks[nextTickToCross].secondsPerLiquidityOutside;
+        ticks[nextTickToCross].secondsGrowthOutside = secondsGrotwhGlobal - ticks[nextTickToCross].secondsGrowthOutside;
         if (zeroForOne) {
             // Moving forward through the linked list
             if (nextTickToCross % 2 == 0) {
@@ -56,7 +56,7 @@ library Ticks {
         mapping(int24 => Tick) storage ticks,
         uint256 feeGrowthGlobal0,
         uint256 feeGrowthGlobal1,
-        uint160 secondsPerLiquidity,
+        uint160 secondsGrotwhGlobal,
         int24 lowerOld,
         int24 lower,
         int24 upperOld,
@@ -83,7 +83,7 @@ library Ticks {
                 require((old.liquidity != 0 || lowerOld == TickMath.MIN_TICK) && lowerOld < lower && lower < oldNextTick, "LOWER_ORDER");
 
                 if (lower <= nearestTick) {
-                    ticks[lower] = Ticks.Tick(lowerOld, oldNextTick, amount, feeGrowthGlobal0, feeGrowthGlobal1, secondsPerLiquidity);
+                    ticks[lower] = Ticks.Tick(lowerOld, oldNextTick, amount, feeGrowthGlobal0, feeGrowthGlobal1, secondsGrotwhGlobal);
                 } else {
                     ticks[lower] = Ticks.Tick(lowerOld, oldNextTick, amount, 0, 0, 0);
                 }
@@ -105,7 +105,7 @@ library Ticks {
             require(old.liquidity != 0 && oldNextTick > upper && upperOld < upper, "UPPER_ORDER");
 
             if (upper <= nearestTick) {
-                ticks[upper] = Ticks.Tick(upperOld, oldNextTick, amount, feeGrowthGlobal0, feeGrowthGlobal1, secondsPerLiquidity);
+                ticks[upper] = Ticks.Tick(upperOld, oldNextTick, amount, feeGrowthGlobal0, feeGrowthGlobal1, secondsGrotwhGlobal);
             } else {
                 ticks[upper] = Ticks.Tick(upperOld, oldNextTick, amount, 0, 0, 0);
             }

--- a/contracts/pool/concentrated/README.md
+++ b/contracts/pool/concentrated/README.md
@@ -30,7 +30,7 @@ We repeat this step untill we use up all of the swap input amount.
 Pool may be trading inside and outside of a given position. To calcualte fees belonging to a specific position we keep track of a couple of counters.
 
 We store a **feeGrowthGlobal** accumulator which increases on every swap step by the swap fee amount divided by the current liquidity `feeGrowthGlobal += feeAmount / currentLiquidity`.
-Every tick also keeps track of it's own **feeGrowthOutside** accumulator. This stores the fee growth that has happened on the side of the tick where trading isn't currently happening. It is updated each time a tick is crossed: `feeGrowthOutside = feeGrowthGlobal - feeGrowthOutside`.
+Every tick also keeps track of it's own **feeGrowthOutside** accumulator. This stores the fee growth that has happened on the side of the tick where trading isn't currently happening. It is updated each time the tick is crossed: `feeGrowthOutside = feeGrowthGlobal - feeGrowthOutside`.
 
 Using the `feeGrowthGlobal` and `feeGrowthOutside` variables we can calculate the feeGrowth that has happened above or below any specific tick.
 
@@ -58,13 +58,13 @@ Projects can provide incentives on any concentrated liquidity pair. Incentives a
 
 We use the same approach as with calculating fees belonging to a position.
 
-The pool keeps track of a global `secondsPerLiquidity` accumulator which increases on every swap by the time between the last measurement, divided by current liquidity `secondsPerLiquidity += secondPassed / liquidity`.
-Each tick also keeps track of the `secondsPerLiquidityOutside` counter which stores the seconds per liquidity growth that has happened on the side of the tick where trading currently isn't happening. It is updated on every tick crossing in the same way as fee counters are.
+The pool keeps track of a `secondsGrowthGlobal` accumulator which increases on every swap by the time between the last increase, divided by current liquidity `secondsGrowthGlobal += secondPassed / liquidity`.
+Each tick also keeps track of the `secondsGrowthOutside` snapshot which stores the growth that has happened on the side of the tick where trading currently isn't happening. It is updated each time the tick is crossed: `secondsGrowthOutside = secondsGrowthGlobal - secondsGrowthOutside`.
 
-Using the global `secondsPerLiquidity` counter and the `secondsPerLiquidityOutside` of a tick we can calculate the current seconds per liquidity above or below any specific tick.
-By subtracting the "seconds per liquidity below" of the lower tick and the "seconds per liquidity above" of the upper tick from the global "seconds per liquidity counter" we get the seconds per liquidity accumulator for a position. When a user wants to stake a snapshot of this value is taken (`secondsInsideLast`).
+Using the `secondsGrowthGlobal` and the `secondsGrowthOutside` counter of a tick we can calculate the current growth that has happened above or below any specific tick.
+By subtracting the "growth below" of the lower tick and the "growth above" of the upper tick from `secondsGrowthGlobal` we get the growth for a position. When a user wants to stake a snapshot of this value is taken (`secondsGrowthInsideLast`).
 
-After some time passes we can calculate the rewards belonging to a position by computing the new `secondsInsideLast` value and calculating the difference from the old value. Multiplying this difference by the position's liquidity gives us an abstract amount in seconds, that will be less than or equal to the time a user has been staked for (e.g. staking duration is 1000 seconds, but the position's seconds value we calculate is 100). We can think of this value as the amount of time trading has relied solely on this position. By dividing the position's time by the total passed time we can compute the ratio of rewards that should be credited to the position (in the example it would be 10% of rewards).
+After some time passes we can calculate the rewards belonging to a position by computing the new `secondsGrowthInsideLast` value and calculating the difference from the old value. Multiplying this difference by the position's liquidity gives us an abstract amount in seconds, that will be less than or equal to the time a user has been staked for (e.g. staking duration is 1000 seconds, but the position's seconds value we calculate is 100). We can think of this value as the amount of time trading has relied solely on this position. By dividing the position's time by the total passed time we can compute the ratio of rewards that should be credited to the position (in the example it would be 10% of rewards).
 
 ## Formulas
 

--- a/test/ConcentratedLiquidityPoolTest.ts
+++ b/test/ConcentratedLiquidityPoolTest.ts
@@ -527,9 +527,9 @@ describe.only("Concentrated Liquidity Product Pool", function () {
           inAmount: maxDy.div(3).mul(2),
           recipient: defaultAddress,
         });
-        const fistSplData = await pool.getSecondsPerLiquidityAndLastObservation();
+        const fistSplData = await pool.getSecondsGrowthAndLastObservation();
         let firstSplA = await trident.concentratedPoolManager.rangeSecondsInside(pool.address, lowerA, upperA);
-        expect((await fistSplData)._secondsPerLiquidity.toString()).to.be.eq(
+        expect((await fistSplData)._secondsGrowthGlobal.toString()).to.be.eq(
           firstSplA.toString(),
           "didn't credit seconds per liquidity to active position"
         );
@@ -541,10 +541,10 @@ describe.only("Concentrated Liquidity Product Pool", function () {
           inAmount: maxDy.div(3).mul(2),
           recipient: defaultAddress,
         });
-        const secondSplData = await pool.getSecondsPerLiquidityAndLastObservation();
+        const secondSplData = await pool.getSecondsGrowthAndLastObservation();
         const secondSplA = await trident.concentratedPoolManager.rangeSecondsInside(pool.address, lowerA, upperA);
         const secondSplB = await trident.concentratedPoolManager.rangeSecondsInside(pool.address, lowerB, upperB);
-        expect(secondSplData._secondsPerLiquidity.toString()).to.be.eq(
+        expect(secondSplData._secondsGrowthGlobal.toString()).to.be.eq(
           secondSplA.toString(),
           "didn't credit seconds per liquidity to active position"
         );
@@ -567,7 +567,7 @@ describe.only("Concentrated Liquidity Product Pool", function () {
       }
     });
 
-    it.only("Should create incentive", async () => {
+    it("Should create incentive", async () => {
       helper.reset();
       const pool = trident.concentratedPools[0];
       const tickSpacing = (await pool.getImmutables())._tickSpacing;

--- a/test/harness/Concentrated.ts
+++ b/test/harness/Concentrated.ts
@@ -94,7 +94,7 @@ export async function swapViaRouter(params: {
   const { pool, zeroForOne, inAmount, recipient, unwrapBento } = params;
   const immutables = await pool.getImmutables();
   const nearest = (await pool.getPriceAndNearestTicks())._nearestTick;
-  const oldSplData = await pool.getSecondsPerLiquidityAndLastObservation();
+  const oldSplData = await pool.getSecondsGrowthAndLastObservation();
   let nextTickToCross = zeroForOne ? nearest : (await pool.ticks(nearest)).nextTick;
   let currentPrice = (await pool.getPriceAndNearestTicks())._price;
   let currentLiquidity = await pool.liquidity();
@@ -198,12 +198,12 @@ export async function swapViaRouter(params: {
   };
 
   const tx = await Trident.Instance.router.exactInputSingle(routerData);
-  const newSplData = await pool.getSecondsPerLiquidityAndLastObservation();
+  const newSplData = await pool.getSecondsGrowthAndLastObservation();
   const block = await ethers.provider.getBlock(tx.blockNumber as number);
   const timeDiff = block.timestamp - oldSplData._lastObservation;
   const splIncrease = TWO_POW_128.mul(timeDiff).div(startingLiquidity);
-  expect(newSplData._secondsPerLiquidity.toString()).to.be.eq(
-    oldSplData._secondsPerLiquidity.add(splIncrease).toString(),
+  expect(newSplData._secondsGrowthGlobal.toString()).to.be.eq(
+    oldSplData._secondsGrowthGlobal.add(splIncrease).toString(),
     "Didn't correctly update global spl counter"
   );
   expect(newSplData._lastObservation).to.be.eq(block.timestamp);


### PR DESCRIPTION
Also, add unchecked block when computing the secondsGrowthGlobal increase to not brick the pools after 2106.