### PR TITLE
Varable rename (secondsGrowthGlobal)

### DIFF
--- a/contracts/interfaces/IConcentratedLiquidityPool.sol
+++ b/contracts/interfaces/IConcentratedLiquidityPool.sol
@@ -48,5 +48,5 @@ interface IConcentratedLiquidityPool is IPool {
 
     function getReserves() external view returns (uint128 _reserve0, uint128 _reserve1);
 
-    function getSecondsPerLiquidityAndLastObservation() external view returns (uint160 _secondsPerLiquidity, uint32 _lastObservation);
+    function getSecondsGrowthAndLastObservation() external view returns (uint160 _secondGrowthGlobal, uint32 _lastObservation);
 }

--- a/contracts/libraries/concentratedPool/Ticks.sol
+++ b/contracts/libraries/concentratedPool/Ticks.sol
@@ -13,7 +13,7 @@ library Ticks {
         uint128 liquidity;
         uint256 feeGrowthOutside0; // Per unit of liquidity.
         uint256 feeGrowthOutside1;
-        uint160 secondsPerLiquidityOutside;
+        uint160 secondsGrowthOutside;
     }
 
     function getMaxLiquidity(uint24 _tickSpacing) internal pure returns (uint128) {
@@ -23,12 +23,12 @@ library Ticks {
     function cross(
         mapping(int24 => Tick) storage ticks,
         int24 nextTickToCross,
-        uint160 secondsPerLiquidity,
+        uint160 secondsGrotwhGlobal,
         uint256 currentLiquidity,
         uint256 feeGrowthGlobal,
         bool zeroForOne
     ) internal returns (uint256, int24) {
-        ticks[nextTickToCross].secondsPerLiquidityOutside = secondsPerLiquidity - ticks[nextTickToCross].secondsPerLiquidityOutside;
+        ticks[nextTickToCross].secondsGrowthOutside = secondsGrotwhGlobal - ticks[nextTickToCross].secondsGrowthOutside;
         if (zeroForOne) {
             // Moving forward through the linked list
             if (nextTickToCross % 2 == 0) {
@@ -56,7 +56,7 @@ library Ticks {
         mapping(int24 => Tick) storage ticks,
         uint256 feeGrowthGlobal0,
         uint256 feeGrowthGlobal1,
-        uint160 secondsPerLiquidity,
+        uint160 secondsGrotwhGlobal,
         int24 lowerOld,
         int24 lower,
         int24 upperOld,
@@ -83,7 +83,7 @@ library Ticks {
                 require((old.liquidity != 0 || lowerOld == TickMath.MIN_TICK) && lowerOld < lower && lower < oldNextTick, "LOWER_ORDER");
 
                 if (lower <= nearestTick) {
-                    ticks[lower] = Ticks.Tick(lowerOld, oldNextTick, amount, feeGrowthGlobal0, feeGrowthGlobal1, secondsPerLiquidity);
+                    ticks[lower] = Ticks.Tick(lowerOld, oldNextTick, amount, feeGrowthGlobal0, feeGrowthGlobal1, secondsGrotwhGlobal);
                 } else {
                     ticks[lower] = Ticks.Tick(lowerOld, oldNextTick, amount, 0, 0, 0);
                 }
@@ -105,7 +105,7 @@ library Ticks {
             require(old.liquidity != 0 && oldNextTick > upper && upperOld < upper, "UPPER_ORDER");
 
             if (upper <= nearestTick) {
-                ticks[upper] = Ticks.Tick(upperOld, oldNextTick, amount, feeGrowthGlobal0, feeGrowthGlobal1, secondsPerLiquidity);
+                ticks[upper] = Ticks.Tick(upperOld, oldNextTick, amount, feeGrowthGlobal0, feeGrowthGlobal1, secondsGrotwhGlobal);
             } else {
                 ticks[upper] = Ticks.Tick(upperOld, oldNextTick, amount, 0, 0, 0);
             }

--- a/test/ConcentratedLiquidityPoolTest.ts
+++ b/test/ConcentratedLiquidityPoolTest.ts
@@ -527,9 +527,9 @@ describe.only("Concentrated Liquidity Product Pool", function () {
           inAmount: maxDy.div(3).mul(2),
           recipient: defaultAddress,
         });
-        const fistSplData = await pool.getSecondsPerLiquidityAndLastObservation();
+        const fistSplData = await pool.getSecondsGrowthAndLastObservation();
         let firstSplA = await trident.concentratedPoolManager.rangeSecondsInside(pool.address, lowerA, upperA);
-        expect((await fistSplData)._secondsPerLiquidity.toString()).to.be.eq(
+        expect((await fistSplData)._secondsGrowthGlobal.toString()).to.be.eq(
           firstSplA.toString(),
           "didn't credit seconds per liquidity to active position"
         );
@@ -541,10 +541,10 @@ describe.only("Concentrated Liquidity Product Pool", function () {
           inAmount: maxDy.div(3).mul(2),
           recipient: defaultAddress,
         });
-        const secondSplData = await pool.getSecondsPerLiquidityAndLastObservation();
+        const secondSplData = await pool.getSecondsGrowthAndLastObservation();
         const secondSplA = await trident.concentratedPoolManager.rangeSecondsInside(pool.address, lowerA, upperA);
         const secondSplB = await trident.concentratedPoolManager.rangeSecondsInside(pool.address, lowerB, upperB);
-        expect(secondSplData._secondsPerLiquidity.toString()).to.be.eq(
+        expect(secondSplData._secondsGrowthGlobal.toString()).to.be.eq(
           secondSplA.toString(),
           "didn't credit seconds per liquidity to active position"
         );
@@ -567,7 +567,7 @@ describe.only("Concentrated Liquidity Product Pool", function () {
       }
     });
 
-    it.only("Should create incentive", async () => {
+    it("Should create incentive", async () => {
       helper.reset();
       const pool = trident.concentratedPools[0];
       const tickSpacing = (await pool.getImmutables())._tickSpacing;

--- a/test/harness/Concentrated.ts
+++ b/test/harness/Concentrated.ts
@@ -94,7 +94,7 @@ export async function swapViaRouter(params: {
   const { pool, zeroForOne, inAmount, recipient, unwrapBento } = params;
   const immutables = await pool.getImmutables();
   const nearest = (await pool.getPriceAndNearestTicks())._nearestTick;
-  const oldSplData = await pool.getSecondsPerLiquidityAndLastObservation();
+  const oldSplData = await pool.getSecondsGrowthAndLastObservation();
   let nextTickToCross = zeroForOne ? nearest : (await pool.ticks(nearest)).nextTick;
   let currentPrice = (await pool.getPriceAndNearestTicks())._price;
   let currentLiquidity = await pool.liquidity();
@@ -198,12 +198,12 @@ export async function swapViaRouter(params: {
   };
 
   const tx = await Trident.Instance.router.exactInputSingle(routerData);
-  const newSplData = await pool.getSecondsPerLiquidityAndLastObservation();
+  const newSplData = await pool.getSecondsGrowthAndLastObservation();
   const block = await ethers.provider.getBlock(tx.blockNumber as number);
   const timeDiff = block.timestamp - oldSplData._lastObservation;
   const splIncrease = TWO_POW_128.mul(timeDiff).div(startingLiquidity);
-  expect(newSplData._secondsPerLiquidity.toString()).to.be.eq(
-    oldSplData._secondsPerLiquidity.add(splIncrease).toString(),
+  expect(newSplData._secondsGrowthGlobal.toString()).to.be.eq(
+    oldSplData._secondsGrowthGlobal.add(splIncrease).toString(),
     "Didn't correctly update global spl counter"
   );
   expect(newSplData._lastObservation).to.be.eq(block.timestamp);


### PR DESCRIPTION
Also, add unchecked {} to secondsGrowthGlobal calculation to prevent pools from getting bricked after the year 2106.