### PR TITLE
Double max tick liquidity

### DIFF
--- a/contracts/libraries/concentratedPool/Ticks.sol
+++ b/contracts/libraries/concentratedPool/Ticks.sol
@@ -17,7 +17,7 @@ library Ticks {
     }
 
     function getMaxLiquidity(uint24 _tickSpacing) internal pure returns (uint128) {
-        return type(uint128).max / uint128(uint24(TickMath.MAX_TICK) / uint24(_tickSpacing));
+        return type(uint128).max / uint128(uint24(TickMath.MAX_TICK) / (2 * uint24(_tickSpacing)));
     }
 
     function cross(


### PR DESCRIPTION
Due to our 'lower even, upper odd' rule we can double the max tick liquidity