### PR TITLE
Refactor util contracts

### DIFF
--- a/contracts/TridentRouter.sol
+++ b/contracts/TridentRouter.sol
@@ -5,14 +5,14 @@ pragma solidity >=0.8.0;
 import "./interfaces/IBentoBoxMinimal.sol";
 import "./interfaces/IPool.sol";
 import "./interfaces/ITridentRouter.sol";
-import "./deployer/MasterDeployer.sol";
+import "./interfaces/IMasterDeployer.sol";
 import "./utils/RouterHelper.sol";
 
 /// @notice Router contract that helps in swapping across Trident pools.
 contract TridentRouter is ITridentRouter, RouterHelper {
     /// @notice BentoBox token vault.
     IBentoBoxMinimal public immutable bento;
-    MasterDeployer public immutable masterDeployer;
+    IMasterDeployer public immutable masterDeployer;
 
     /// @dev Used to ensure that `tridentSwapCallback` is called only by the authorized address.
     /// These are set when someone calls a flash swap and reset afterwards.
@@ -23,7 +23,7 @@ contract TridentRouter is ITridentRouter, RouterHelper {
 
     constructor(
         IBentoBoxMinimal _bento,
-        MasterDeployer _masterDeployer,
+        IMasterDeployer _masterDeployer,
         address _wETH
     ) RouterHelper(_wETH) {
         _bento.registerProtocol();

--- a/contracts/TridentRouter.sol
+++ b/contracts/TridentRouter.sol
@@ -5,11 +5,11 @@ pragma solidity >=0.8.0;
 import "./interfaces/IBentoBoxMinimal.sol";
 import "./interfaces/IPool.sol";
 import "./interfaces/ITridentRouter.sol";
-import "./utils/TridentHelper.sol";
 import "./deployer/MasterDeployer.sol";
+import "./utils/RouterHelper.sol";
 
 /// @notice Router contract that helps in swapping across Trident pools.
-contract TridentRouter is ITridentRouter, TridentHelper {
+contract TridentRouter is ITridentRouter, RouterHelper {
     /// @notice BentoBox token vault.
     IBentoBoxMinimal public immutable bento;
     MasterDeployer public immutable masterDeployer;
@@ -25,7 +25,7 @@ contract TridentRouter is ITridentRouter, TridentHelper {
         IBentoBoxMinimal _bento,
         MasterDeployer _masterDeployer,
         address _wETH
-    ) TridentHelper(_wETH) {
+    ) RouterHelper(_wETH) {
         _bento.registerProtocol();
         bento = _bento;
         masterDeployer = _masterDeployer;

--- a/contracts/utils/RouterHelper.sol
+++ b/contracts/utils/RouterHelper.sol
@@ -18,7 +18,7 @@ contract RouterHelper {
     /// @notice Provides batch function calls for this contract and returns the data from all of them if they all succeed.
     /// Adapted from https://github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/base/Multicall.sol, License-Identifier: GPL-2.0-or-later.
     /// @dev The `msg.value` should not be trusted for any method callable from this function.
-    /// @dev Uses a modified version of the batch function - preventing multiple calls of the swap functions
+    /// @dev Uses a modified version of the batch function - preventing multiple calls of the single input swap functions
     /// @param data ABI-encoded params for each of the calls to make to this contract.
     /// @return results The results from each of the calls passed in via `data`.
     function batch(bytes[] calldata data) external payable returns (bytes[] memory results) {
@@ -38,7 +38,7 @@ contract RouterHelper {
 
             (bool success, bytes memory result) = address(this).delegatecall(data[i]);
             if (!success) {
-                // @dev Next 5 lines from https://ethereum.stackexchange.com/a/83577.
+                // Next 5 lines from https://ethereum.stackexchange.com/a/83577.
                 if (result.length < 68) revert();
                 assembly {
                     result := add(result, 0x04)

--- a/contracts/utils/RouterHelper.sol
+++ b/contracts/utils/RouterHelper.sol
@@ -3,9 +3,10 @@
 pragma solidity >=0.8.0;
 
 import "../TridentRouter.sol";
+import "./TridentPermit.sol";
 
 /// @notice Trident router helper contract.
-contract RouterHelper {
+contract RouterHelper is TridentPermit {
     /// @notice ERC-20 token for wrapped ETH (v9).
     address internal immutable wETH;
     /// @notice The user should use 0x0 if they want to deposit ETH
@@ -56,44 +57,6 @@ contract RouterHelper {
         (bool success, bytes memory data) = token.staticcall(abi.encodeWithSelector(0x70a08231, address(this))); // @dev balanceOf(address).
         require(success && data.length >= 32, "BALANCE_OF_FAILED");
         balance = abi.decode(data, (uint256));
-    }
-
-    /// @notice Provides EIP-2612 signed approval for this contract to spend user tokens.
-    /// @param token Address of ERC-20 token.
-    /// @param amount Token amount to grant spending right over.
-    /// @param deadline Termination for signed approval (UTC timestamp in seconds).
-    /// @param v The recovery byte of the signature.
-    /// @param r Half of the ECDSA signature pair.
-    /// @param s Half of the ECDSA signature pair.
-    function permitThis(
-        address token,
-        uint256 amount,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external {
-        (bool success, ) = token.call(abi.encodeWithSelector(0xd505accf, msg.sender, address(this), amount, deadline, v, r, s)); // @dev permit(address,address,uint256,uint256,uint8,bytes32,bytes32).
-        require(success, "PERMIT_FAILED");
-    }
-
-    /// @notice Provides DAI-derived signed approval for this contract to spend user tokens.
-    /// @param token Address of ERC-20 token.
-    /// @param nonce Token owner's nonce - increases at each call to {permit}.
-    /// @param expiry Termination for signed approval - UTC timestamp in seconds.
-    /// @param v The recovery byte of the signature.
-    /// @param r Half of the ECDSA signature pair.
-    /// @param s Half of the ECDSA signature pair.
-    function permitThisAllowed(
-        address token,
-        uint256 nonce,
-        uint256 expiry,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external {
-        (bool success, ) = token.call(abi.encodeWithSelector(0x8fcbaf0c, msg.sender, address(this), nonce, expiry, true, v, r, s)); // @dev permit(address,address,uint256,uint256,bool,uint8,bytes32,bytes32).
-        require(success, "PERMIT_FAILED");
     }
 
     /// @notice Provides 'safe' ERC-20 {transfer} for tokens that don't consistently return true/false.

--- a/contracts/utils/RouterHelper.sol
+++ b/contracts/utils/RouterHelper.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.0;
 import "../TridentRouter.sol";
 
 /// @notice Trident router helper contract.
-contract TridentHelper {
+contract RouterHelper {
     /// @notice ERC-20 token for wrapped ETH (v9).
     address internal immutable wETH;
     /// @notice The user should use 0x0 if they want to deposit ETH
@@ -18,6 +18,7 @@ contract TridentHelper {
     /// @notice Provides batch function calls for this contract and returns the data from all of them if they all succeed.
     /// Adapted from https://github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/base/Multicall.sol, License-Identifier: GPL-2.0-or-later.
     /// @dev The `msg.value` should not be trusted for any method callable from this function.
+    /// @dev Uses a modified version of the batch function - preventing multiple calls of the swap functions
     /// @param data ABI-encoded params for each of the calls to make to this contract.
     /// @return results The results from each of the calls passed in via `data`.
     function batch(bytes[] calldata data) external payable returns (bytes[] memory results) {

--- a/contracts/utils/TridentBatchable.sol
+++ b/contracts/utils/TridentBatchable.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity >=0.8.0;
+
+/// @notice Generic contract exposing the batch call functionality.
+abstract contract TridentBatchable {
+    /// @notice Provides batch function calls for this contract and returns the data from all of them if they all succeed.
+    /// Adapted from https://github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/base/Multicall.sol, License-Identifier: GPL-2.0-or-later.
+    /// @dev The `msg.value` should not be trusted for any method callable from this function.
+    /// @param data ABI-encoded params for each of the calls to make to this contract.
+    /// @return results The results from each of the calls passed in via `data`.
+    function batch(bytes[] calldata data) external payable returns (bytes[] memory results) {
+        results = new bytes[](data.length);
+
+        for (uint256 i = 0; i < data.length; i++) {
+            (bool success, bytes memory result) = address(this).delegatecall(data[i]);
+
+            if (!success) {
+                // Next 5 lines from https://ethereum.stackexchange.com/a/83577
+                if (result.length < 68) revert();
+                assembly {
+                    result := add(result, 0x04)
+                }
+                revert(abi.decode(result, (string)));
+            }
+
+            results[i] = result;
+        }
+    }
+}

--- a/contracts/utils/TridentPermit.sol
+++ b/contracts/utils/TridentPermit.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity >=0.8.0;
+
+/// @notice Generic contract exposing the permit functionality.
+abstract contract TridentPermit {
+    /// @notice Provides EIP-2612 signed approval for this contract to spend user tokens.
+    /// @param token Address of ERC-20 token.
+    /// @param amount Token amount to grant spending right over.
+    /// @param deadline Termination for signed approval (UTC timestamp in seconds).
+    /// @param v The recovery byte of the signature.
+    /// @param r Half of the ECDSA signature pair.
+    /// @param s Half of the ECDSA signature pair.
+    function permitThis(
+        address token,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        (bool success, ) = token.call(abi.encodeWithSelector(0xd505accf, msg.sender, address(this), amount, deadline, v, r, s)); // @dev permit(address,address,uint256,uint256,uint8,bytes32,bytes32).
+        require(success, "PERMIT_FAILED");
+    }
+
+    /// @notice Provides DAI-derived signed approval for this contract to spend user tokens.
+    /// @param token Address of ERC-20 token.
+    /// @param nonce Token owner's nonce - increases at each call to {permit}.
+    /// @param expiry Termination for signed approval - UTC timestamp in seconds.
+    /// @param v The recovery byte of the signature.
+    /// @param r Half of the ECDSA signature pair.
+    /// @param s Half of the ECDSA signature pair.
+    function permitThisAllowed(
+        address token,
+        uint256 nonce,
+        uint256 expiry,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        (bool success, ) = token.call(abi.encodeWithSelector(0x8fcbaf0c, msg.sender, address(this), nonce, expiry, true, v, r, s)); // @dev permit(address,address,uint256,uint256,bool,uint8,bytes32,bytes32).
+        require(success, "PERMIT_FAILED");
+    }
+}

--- a/contracts/utils/TridentPermit.sol
+++ b/contracts/utils/TridentPermit.sol
@@ -19,7 +19,7 @@ abstract contract TridentPermit {
         bytes32 r,
         bytes32 s
     ) external {
-        (bool success, ) = token.call(abi.encodeWithSelector(0xd505accf, msg.sender, address(this), amount, deadline, v, r, s)); // @dev permit(address,address,uint256,uint256,uint8,bytes32,bytes32).
+        (bool success, ) = token.call(abi.encodeWithSelector(0xd505accf, msg.sender, address(this), amount, deadline, v, r, s)); // permit(address,address,uint256,uint256,uint8,bytes32,bytes32).
         require(success, "PERMIT_FAILED");
     }
 
@@ -38,7 +38,7 @@ abstract contract TridentPermit {
         bytes32 r,
         bytes32 s
     ) external {
-        (bool success, ) = token.call(abi.encodeWithSelector(0x8fcbaf0c, msg.sender, address(this), nonce, expiry, true, v, r, s)); // @dev permit(address,address,uint256,uint256,bool,uint8,bytes32,bytes32).
+        (bool success, ) = token.call(abi.encodeWithSelector(0x8fcbaf0c, msg.sender, address(this), nonce, expiry, true, v, r, s)); // permit(address,address,uint256,uint256,bool,uint8,bytes32,bytes32).
         require(success, "PERMIT_FAILED");
     }
 }


### PR DESCRIPTION
Split out the batch and the permit functionalities from the RouterHelper (prev. TridentHelper) as it was specific to the router so that other contracts can easily extend with the needed functionalities.