### PR TITLE
Uniqueness check on pool whitelisting

### DIFF
--- a/contracts/deployer/MasterDeployer.sol
+++ b/contracts/deployer/MasterDeployer.sol
@@ -2,6 +2,7 @@
 
 pragma solidity >=0.8.0;
 
+import "../interfaces/IPool.sol";
 import "../interfaces/IPoolFactory.sol";
 import "../utils/TridentOwnable.sol";
 
@@ -16,11 +17,17 @@ contract MasterDeployer is TridentOwnable {
     uint256 public barFee;
     address public immutable barFeeTo;
     address public immutable bento;
+    address[] public factoryList;
 
     uint256 internal constant MAX_FEE = 10000; // @dev 100%.
 
     mapping(address => bool) public pools;
-    mapping(address => bool) public whitelistedFactories;
+    mapping(address => Type) public factories;
+    
+    struct Type {
+        bool whitelisted;
+        bytes32 identifier;
+    }
 
     constructor(
         uint256 _barFee,
@@ -37,19 +44,24 @@ contract MasterDeployer is TridentOwnable {
     }
 
     function deployPool(address _factory, bytes calldata _deployData) external returns (address pool) {
-        require(whitelistedFactories[_factory], "FACTORY_NOT_WHITELISTED");
+        require(factories[_factory].whitelisted, "FACTORY_NOT_WHITELISTED");
         pool = IPoolFactory(_factory).deployPool(_deployData);
         pools[pool] = true;
         emit DeployPool(_factory, pool, _deployData);
     }
 
     function addToWhitelist(address _factory) external onlyOwner {
-        whitelistedFactories[_factory] = true;
+        bytes32 identifier = IPool(_factory).poolIdentifier();
+        for (uint256 i = 0; i < factoryList.length; i++) {
+            require(identifier != factories[factoryList[i]].identifier, "FACTORY_NOT_UNIQUE");
+        }
+        factories[_factory] = Type(true, identifier);
+        factoryList.push(_factory);
         emit AddToWhitelist(_factory);
     }
 
     function removeFromWhitelist(address _factory) external onlyOwner {
-        whitelistedFactories[_factory] = false;
+        factories[_factory].whitelisted = false;
         emit RemoveFromWhitelist(_factory);
     }
 

--- a/contracts/pool/ConstantProductPoolFactory.sol
+++ b/contracts/pool/ConstantProductPoolFactory.sol
@@ -8,6 +8,8 @@ import "./PoolDeployer.sol";
 /// @notice Contract for deploying Trident exchange Constant Product Pool with configurations.
 /// @author Mudit Gupta.
 contract ConstantProductPoolFactory is PoolDeployer {
+    bytes32 public constant poolIdentifier = "Trident:ConstantProduct";
+    
     constructor(address _masterDeployer) PoolDeployer(_masterDeployer) {}
 
     function deployPool(bytes memory _deployData) external returns (address pool) {

--- a/contracts/pool/ConstantProductPoolFactory.sol
+++ b/contracts/pool/ConstantProductPoolFactory.sol
@@ -19,14 +19,14 @@ contract ConstantProductPoolFactory is PoolDeployer {
             (tokenA, tokenB) = (tokenB, tokenA);
         }
 
-        // @dev Strips any extra data.
+        // Strips any extra data.
         _deployData = abi.encode(tokenA, tokenB, swapFee, twapSupport);
 
         address[] memory tokens = new address[](2);
         tokens[0] = tokenA;
         tokens[1] = tokenB;
 
-        // @dev Salt is not actually needed since `_deployData` is part of creationCode and already contains the salt.
+        // Salt is not actually needed since `_deployData` is part of creationCode and already contains the salt.
         bytes32 salt = keccak256(_deployData);
         pool = address(new ConstantProductPool{salt: salt}(_deployData, masterDeployer));
         _registerPool(pool, tokens, salt);

--- a/contracts/pool/HybridPoolFactory.sol
+++ b/contracts/pool/HybridPoolFactory.sol
@@ -8,6 +8,8 @@ import "./PoolDeployer.sol";
 /// @notice Contract for deploying Trident exchange Hybrid Pool with configurations.
 /// @author Mudit Gupta.
 contract HybridPoolFactory is PoolDeployer {
+    bytes32 public constant poolIdentifier = "Trident:HybridPool";
+    
     constructor(address _masterDeployer) PoolDeployer(_masterDeployer) {}
 
     function deployPool(bytes memory _deployData) external returns (address pool) {

--- a/contracts/pool/HybridPoolFactory.sol
+++ b/contracts/pool/HybridPoolFactory.sol
@@ -19,13 +19,13 @@ contract HybridPoolFactory is PoolDeployer {
             (tokenA, tokenB) = (tokenB, tokenA);
         }
 
-        // @dev Strips any extra data.
+        // Strips any extra data.
         _deployData = abi.encode(tokenA, tokenB, swapFee, a);
         address[] memory tokens = new address[](2);
         tokens[0] = tokenA;
         tokens[1] = tokenB;
 
-        // @dev Salt is not actually needed since `_deployData` is part of creationCode and already contains the salt.
+        // Salt is not actually needed since `_deployData` is part of creationCode and already contains the salt.
         bytes32 salt = keccak256(_deployData);
         pool = address(new HybridPool{salt: salt}(_deployData, masterDeployer));
         _registerPool(pool, tokens, salt);

--- a/contracts/pool/IndexPoolFactory.sol
+++ b/contracts/pool/IndexPoolFactory.sol
@@ -15,10 +15,10 @@ contract IndexPoolFactory is PoolDeployer {
     function deployPool(bytes memory _deployData) external returns (address pool) {
         (address[] memory tokens, uint136[] memory weights, uint256 swapFee) = abi.decode(_deployData, (address[], uint136[], uint256));
 
-        // @dev Strips any extra data.
+        // Strips any extra data.
         _deployData = abi.encode(tokens, weights, swapFee);
 
-        // @dev Salt is not actually needed since `_deployData` is part of creationCode and already contains the salt.
+        // Salt is not actually needed since `_deployData` is part of creationCode and already contains the salt.
         bytes32 salt = keccak256(_deployData);
         pool = address(new IndexPool{salt: salt}(_deployData, masterDeployer));
         _registerPool(pool, tokens, salt);

--- a/contracts/pool/IndexPoolFactory.sol
+++ b/contracts/pool/IndexPoolFactory.sol
@@ -8,6 +8,8 @@ import "./PoolDeployer.sol";
 /// @notice Contract for deploying Trident exchange Index Pool with configurations.
 /// @author Mudit Gupta
 contract IndexPoolFactory is PoolDeployer {
+    bytes32 public constant poolIdentifier = "Trident:Index";
+
     constructor(address _masterDeployer) PoolDeployer(_masterDeployer) {}
 
     function deployPool(bytes memory _deployData) external returns (address pool) {

--- a/contracts/pool/concentrated/ConcentratedLiquidityPoolFactory.sol
+++ b/contracts/pool/concentrated/ConcentratedLiquidityPoolFactory.sol
@@ -8,6 +8,8 @@ import "../PoolDeployer.sol";
 /// @notice Contract for deploying Trident exchange Concentrated Liquidity Pool with configurations.
 /// @author Mudit Gupta.
 contract ConcentratedLiquidityPoolFactory is PoolDeployer {
+    bytes32 public constant poolIdentifier = "Trident:ConcentratedLiquidity";
+    
     constructor(address _masterDeployer) PoolDeployer(_masterDeployer) {}
 
     function deployPool(bytes memory _deployData) external returns (address pool) {
@@ -18,14 +20,14 @@ contract ConcentratedLiquidityPoolFactory is PoolDeployer {
         if (tokenA > tokenB) {
             (tokenA, tokenB) = (tokenB, tokenA);
         }
-        // @dev Strips any extra data.
+        // Strips any extra data.
         _deployData = abi.encode(tokenA, tokenB, swapFee, price, tickSpacing);
 
         address[] memory tokens = new address[](2);
         tokens[0] = tokenA;
         tokens[1] = tokenB;
 
-        // @dev Salt is not actually needed since `_deployData` is part of creationCode and already contains the salt.
+        // Salt is not actually needed since `_deployData` is part of creationCode and already contains the salt.
         bytes32 salt = keccak256(_deployData);
         pool = address(new ConcentratedLiquidityPool{salt: salt}(_deployData, IMasterDeployer(masterDeployer)));
         _registerPool(pool, tokens, salt);


### PR DESCRIPTION
adds check in `addToWhitelist` that reads from stored pool identifier to confirm duplicative pools are not added to `MasterDeployer` whitelist. 

seeks to resolve https://github.com/sushiswap/trident/issues/253