### PR TITLE
Rm Modulo

### DIFF
--- a/contracts/pool/ConstantProductPool.sol
+++ b/contracts/pool/ConstantProductPool.sol
@@ -278,7 +278,7 @@ contract ConstantProductPool is IPool, TridentERC20 {
             reserve0 = uint112(balance0);
             reserve1 = uint112(balance1);
         } else {
-            uint32 blockTimestamp = uint32(block.timestamp % 2**32);
+            uint32 blockTimestamp = uint32(block.timestamp);
             if (blockTimestamp != _blockTimestampLast && _reserve0 != 0 && _reserve1 != 0) {
                 unchecked {
                     uint32 timeElapsed = blockTimestamp - _blockTimestampLast;

--- a/contracts/pool/franchised/FranchisedConstantProductPool.sol
+++ b/contracts/pool/franchised/FranchisedConstantProductPool.sol
@@ -297,7 +297,7 @@ contract FranchisedConstantProductPool is IPool, TridentFranchisedERC20 {
             reserve0 = uint112(balance0);
             reserve1 = uint112(balance1);
         } else {
-            uint32 blockTimestamp = uint32(block.timestamp % 2**32);
+            uint32 blockTimestamp = uint32(block.timestamp);
             if (blockTimestamp != _blockTimestampLast && _reserve0 != 0 && _reserve1 != 0) {
                 unchecked {
                     uint32 timeElapsed = blockTimestamp - _blockTimestampLast;


### PR DESCRIPTION

Reviewer @gasperbr
#### Changes
Removes redundant modulo operation
It's already cast to uint32 so it will truncate the upper bytes already.
And if it wasn't, it would be better to use AND than MOD; MOD uses 5 gas while AND uses 3.