### PR TITLE
Make `BentoBoxV1Flat` compile with solc 0.8.x

### DIFF
--- a/contracts/flat/BentoBoxV1Flat.sol
+++ b/contracts/flat/BentoBoxV1Flat.sol
@@ -183,17 +183,17 @@ library BoringMath {
     }
 
     function to128(uint256 a) internal pure returns (uint128 c) {
-        require(a <= uint128(-1), "BoringMath: uint128 Overflow");
+        require(a <= type(uint128).max, "BoringMath: uint128 Overflow");
         c = uint128(a);
     }
 
     function to64(uint256 a) internal pure returns (uint64 c) {
-        require(a <= uint64(-1), "BoringMath: uint64 Overflow");
+        require(a <= type(uint64).max, "BoringMath: uint64 Overflow");
         c = uint64(a);
     }
 
     function to32(uint256 a) internal pure returns (uint32 c) {
-        require(a <= uint32(-1), "BoringMath: uint32 Overflow");
+        require(a <= type(uint32).max, "BoringMath: uint32 Overflow");
         c = uint32(a);
     }
 }
@@ -705,7 +705,7 @@ contract BentoBoxV1 is MasterContractManager, BoringBatchable {
     // V2: Private to save gas, to verify it's correct, check the constructor arguments
     IERC20 private immutable wethToken;
 
-    IERC20 private constant USE_ETHEREUM = IERC20(0);
+    IERC20 private constant USE_ETHEREUM = IERC20(address(0));
     uint256 private constant FLASH_LOAN_FEE = 50; // 0.05%
     uint256 private constant FLASH_LOAN_FEE_PRECISION = 1e5;
     uint256 private constant STRATEGY_DELAY = 0 weeks;
@@ -1076,7 +1076,7 @@ contract BentoBoxV1 is MasterContractManager, BoringBatchable {
             strategy[token] = pending;
             data.strategyStartDate = 0;
             data.balance = 0;
-            pendingStrategy[token] = IStrategy(0);
+            pendingStrategy[token] = IStrategy(address(0));
             emit LogStrategySet(token, newStrategy);
         }
         strategyData[token] = data;


### PR DESCRIPTION
This PR adds a few minor tweaks in `BentoBoxV1Flat` to make it compile with both solc 0.6.12 and 0.8.10. Changes are purely syntactic and do not affect functionality in any way.

The reason I'd like these changes merged in is that in Solidity we wanted to add Trident to the set of external contracts we use in addition to our normal CI test suite for verifying that changes in the compiler do not break real-life projects (https://github.com/ethereum/solidity/pull/12197). Most of the project already compiles just fine with 0.8.10. `BentoBoxV1Flat.sol` is the only contract that fails and these simple tweaks seem to be enough to make it compatible.